### PR TITLE
Rework oven into a trait, add buffers and more result functions

### DIFF
--- a/examples/intresult.rs
+++ b/examples/intresult.rs
@@ -26,9 +26,9 @@ use clap::*;
 use log::{info, Level};
 
 use memflow::prelude::v1::*;
-use reflow::prelude::v1::*;
+use reflow::prelude::v1::{Result, *};
 
-fn main() {
+fn main() -> Result<()> {
     let matches = App::new("integer result example")
         .version(crate_version!())
         .author(crate_authors!())
@@ -82,15 +82,19 @@ fn main() {
     let mut process = os.into_process_by_name("ConsoleApplication1.exe").unwrap();
     let module = process.module_by_name("ConsoleApplication1.exe").unwrap();
 
-    let mut execution = Oven::new(process)
-        .stack(Stack::new().ret_addr(0x1234u64))
-        .entry_point(module.base + 0x110e1);
+    let mut execution = new_oven(&mut process)?;
 
-    let result = execution.reflow().expect("unable to execute function");
+    let result = execution
+        .stack(Stack::new().ret_addr(0x1234u64))?
+        .entry_point(module.base + 0x110e1)?
+        .reflow()?;
+
     info!(
         "result: {}",
         result
             .reg_read_u64(RegisterX86::EAX)
             .expect("unable to read register") as i32
     );
+
+    Ok(())
 }

--- a/src/execution.rs
+++ b/src/execution.rs
@@ -3,3 +3,39 @@ pub use result::ExecutionResult;
 
 pub mod x86;
 pub use x86::{ExecutionX86, ExecutionX86Arch};
+
+use crate::params::Parameters;
+use crate::stack::Stack;
+
+use memflow::prelude::v1::*;
+
+pub type Result<T> = std::result::Result<T, String>;
+
+pub trait Execution<'a> {
+    fn set_stack(&mut self, stack: Stack) -> Result<()>;
+
+    fn set_params(&mut self, params: Parameters<'a>) -> Result<()>;
+
+    fn set_entry_point(&mut self, entry_point: Address) -> Result<()>;
+
+    fn reflow<'b>(&'b mut self) -> Result<ExecutionResult<'b>>;
+}
+
+pub trait ExecutionHelper<'a>: Execution<'a> {
+    fn stack(&mut self, stack: Stack) -> Result<&mut Self> {
+        Execution::set_stack(self, stack)?;
+        Ok(self)
+    }
+
+    fn params(&mut self, params: Parameters<'a>) -> Result<&mut Self> {
+        Execution::set_params(self, params)?;
+        Ok(self)
+    }
+
+    fn entry_point(&mut self, entry_point: Address) -> Result<&mut Self> {
+        Execution::set_entry_point(self, entry_point)?;
+        Ok(self)
+    }
+}
+
+impl<'a, T: Execution<'a> + ?Sized> ExecutionHelper<'a> for T {}

--- a/src/execution/result.rs
+++ b/src/execution/result.rs
@@ -1,18 +1,33 @@
 use unicorn::*;
 
-pub struct ExecutionResult {
-    pub(crate) emu: CpuX86,
+use crate::result::Result;
+
+pub struct ExecutionResult<'a> {
+    pub(crate) emu: &'a mut CpuX86,
 }
 
-impl ExecutionResult {
-    pub fn new(emu: CpuX86) -> Self {
+impl<'a> ExecutionResult<'a> {
+    pub fn new(emu: &'a mut CpuX86) -> Self {
         Self { emu }
     }
 
-    pub fn reg_read_u64(&self, reg: RegisterX86) -> std::result::Result<u64, &'static str> {
+    pub fn reg_read_u64(&self, reg: RegisterX86) -> Result<u64> {
         self.emu
             .reg_read(reg)
-            .map_err(|_| "unable to read register")
+            .map_err(|_| "unable to read register".into())
+    }
+
+    pub fn reg_read_str(&self, reg: RegisterX86) -> Result<String> {
+        let addr = self.reg_read_u64(reg)?;
+        let mut buf = vec![0; 0x200];
+        self.emu
+            .mem_read(addr, &mut buf)
+            .map_err(|_| "unable to read memory")?;
+
+        Ok(
+            String::from_utf8_lossy(&(buf.into_iter().take_while(|v| *v != 0).collect::<Vec<_>>()))
+                .to_string(),
+        )
     }
 
     // TODO: more helper functions

--- a/src/execution/x86.rs
+++ b/src/execution/x86.rs
@@ -63,8 +63,6 @@ impl<'a, T: 'a + VirtualMemory> Oven<'a> for ExecutionX86<'a, T> {
     fn set_stack(&mut self, stack: Stack) -> Result<()> {
         self.data_base = self.arch.max_writable_addr() - DATA_SIZE as u64 + 1;
 
-        println!("{:x} | {:x}", stack.base, stack.size);
-
         // initialize memory for stack if needed
         if self
             .emu

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
 pub mod execution;
 pub mod oven;
 pub mod params;
+pub mod result;
 pub mod stack;
 
 pub mod prelude {
     pub mod v1 {
-        pub use crate::oven::Oven;
+        pub use crate::oven::{new_oven, new_oven_with_arch, Oven, OvenBuilder};
         pub use crate::params::Parameters;
+        pub use crate::result::Result;
         pub use crate::stack::Stack;
 
         // forward exports

--- a/src/params.rs
+++ b/src/params.rs
@@ -6,11 +6,14 @@ pub enum Parameter<'a> {
     Push64(u64),
     PushStr(&'a str),
     PushString(String),
+    PushBuf(usize),
     // TODO: Pod objects?
     Reg32(RegisterX86, u32),
     Reg64(RegisterX86, u64),
     RegStr(RegisterX86, &'a str),
     RegString(RegisterX86, String),
+    RegBuf(RegisterX86, usize),
+    MovReg(RegisterX86, RegisterX86),
 }
 
 #[derive(Debug, Clone)]
@@ -45,6 +48,11 @@ impl<'a> Parameters<'a> {
         self
     }
 
+    pub fn push_buf(mut self, size: usize) -> Self {
+        self.entries.push(Parameter::PushBuf(size));
+        self
+    }
+
     pub fn reg_u32(mut self, reg: RegisterX86, value: u32) -> Self {
         self.entries.push(Parameter::Reg32(reg, value));
         self
@@ -62,6 +70,16 @@ impl<'a> Parameters<'a> {
 
     pub fn reg_string(mut self, reg: RegisterX86, value: String) -> Self {
         self.entries.push(Parameter::RegString(reg, value));
+        self
+    }
+
+    pub fn reg_buf(mut self, reg: RegisterX86, size: usize) -> Self {
+        self.entries.push(Parameter::RegBuf(reg, size));
+        self
+    }
+
+    pub fn mov_reg(mut self, from: RegisterX86, to: RegisterX86) -> Self {
+        self.entries.push(Parameter::MovReg(from, to));
         self
     }
 }

--- a/src/result.rs
+++ b/src/result.rs
@@ -1,0 +1,3 @@
+// TODO: define a proper int result
+
+pub type Result<T> = std::result::Result<T, Box<dyn std::error::Error>>;


### PR DESCRIPTION
Oven is now a trait, and creation of ovens is done through `new_oven`, and `new_oven_with_arch`. `new_oven` takes a mut ref process, whereas `new_oven_with_arch` takes a virtual mem mut ref alongside arch. I also made some changes with lifetimes, and added more options for parameters, like allocating buffers, and register moves so that one could back up the input register into a non-volatile one for results reading.